### PR TITLE
Added questions screen, button icon, logo opacity & code refactoring

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_quiz_app/custom_widgets/gradient_container.dart';
-import 'package:flutter_quiz_app/custom_widgets/start_screen.dart';
+import 'package:flutter_quiz_app/quiz.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: Scaffold(
-        body: GradientContainer(
-          color1: Color.fromARGB(255, 31, 0, 63),
-          color2: Color.fromARGB(255, 125, 42, 170),
-          children: StartScreen(),
-        ),
-      ),
-    ),
+    const Quiz(),
   );
 }

--- a/lib/quiz.dart
+++ b/lib/quiz.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_quiz_app/custom_widgets/gradient_container.dart';
+import 'package:flutter_quiz_app/screens/start_screen.dart';
+
+class Quiz extends StatefulWidget {
+  const Quiz({super.key});
+
+  @override
+  State<Quiz> createState() {
+    return _QuizState();
+  }
+}
+
+class _QuizState extends State<Quiz> {
+  @override
+  Widget build(context) {
+    return const MaterialApp(
+      home: Scaffold(
+        body: GradientContainer(
+          color1: Color.fromARGB(255, 31, 0, 63),
+          color2: Color.fromARGB(255, 125, 42, 170),
+          children: StartScreen(),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/questions_screen.dart
+++ b/lib/screens/questions_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class QuestionsScreen extends StatefulWidget {
+  const QuestionsScreen({super.key});
+
+  @override
+  State<QuestionsScreen> createState() {
+    return _QuestionsScreenState();
+  }
+}
+
+class _QuestionsScreenState extends State<QuestionsScreen> {
+  @override
+  Widget build(context) {
+    return const Text("Questions screen");
+  }
+}

--- a/lib/screens/start_screen.dart
+++ b/lib/screens/start_screen.dart
@@ -13,6 +13,7 @@ class StartScreen extends StatelessWidget {
           Image.asset(
             'assets/images/quiz-logo.png',
             width: 250,
+            color: Color.fromARGB(153, 255, 255, 255),
           ),
           const SizedBox(
             height: 70,
@@ -22,9 +23,11 @@ class StartScreen extends StatelessWidget {
           const SizedBox(
             height: 30,
           ),
-          OutlinedButton(
+          OutlinedButton.icon(
             onPressed: () {},
-            child: const StyledText('Start Quiz', fontSize: 18),
+            style: OutlinedButton.styleFrom(foregroundColor: Colors.white),
+            icon: const Icon(Icons.arrow_right_alt),
+            label: const StyledText('Start Quiz', fontSize: 18),
           )
         ],
       ),


### PR DESCRIPTION
Proposed changes: 

- Added questions screen for future use. Stateful widget used. 
- Added right arrow icon on outlined button.
- Adjusted opacity of start screen logo. 
- Refactored code: Moved MaterialApp widget from main.dart to separate stateful widget for lifting of state in the future. 

Screenshots:

<img width="379" alt="Screenshot 2023-05-10 at 10 31 51 PM" src="https://github.com/chiraag918/flutter_quiz_app/assets/39455997/3f89da94-f2ea-4510-8749-294032cbea4f">
