### PR TITLE
Developed results screen and made app functional

### DIFF
--- a/lib/custom_widgets/answer_option.dart
+++ b/lib/custom_widgets/answer_option.dart
@@ -16,7 +16,7 @@ class AnswerOption extends StatelessWidget {
           vertical: 5,
           horizontal: 40,
         ),
-        backgroundColor: Color.fromARGB(255, 50, 0, 96),
+        backgroundColor: const Color.fromARGB(255, 50, 0, 96),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(40),
         ),

--- a/lib/custom_widgets/answer_summary.dart
+++ b/lib/custom_widgets/answer_summary.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_quiz_app/custom_widgets/circlular_text_field.dart';
+import 'package:flutter_quiz_app/custom_widgets/styled_text.dart';
+
+class AnswerSummary extends StatelessWidget {
+  const AnswerSummary({super.key, required this.answerSummary});
+
+  final Map<String, Object> answerSummary;
+
+  @override
+  Widget build(context) {
+    return Column(
+      children: [
+        StyledText(
+          'You have correctly answered questions ${answerSummary['noCorrectlyAnswered']} out of ${answerSummary['noQuestions']}',
+          fontSize: 22,
+          fontColor: const Color.fromARGB(255, 247, 157, 255),
+          googleFont: true,
+        ),
+        const SizedBox(height: 30),
+        SizedBox(
+          height: 300,
+          child: SingleChildScrollView(
+            child: Column(children: [
+              ...(answerSummary['summaryList'] as List<Map<String, Object>>)
+                  .map((summaryItem) {
+                return Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    CircularTextField(
+                      circleRadius: 14,
+                      backgroundColor: summaryItem["answeredCorrectly"] as bool
+                          ? const Color.fromARGB(255, 73, 222, 255)
+                          : const Color.fromARGB(255, 243, 114, 254),
+                      text:
+                          ((summaryItem['question_idx'] as int) + 1).toString(),
+                    ),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          StyledText(
+                            summaryItem['question'] as String,
+                            fontSize: 16,
+                            textAlign: TextAlign.start,
+                            googleFont: true,
+                          ),
+                          const SizedBox(
+                            height: 6,
+                          ),
+                          StyledText(
+                            summaryItem['correctAnswer'] as String,
+                            fontSize: 14,
+                            fontColor: const Color.fromARGB(255, 73, 222, 255),
+                            textAlign: TextAlign.start,
+                          ),
+                          StyledText(
+                            summaryItem['selectedAnswer'] as String,
+                            fontSize: 14,
+                            fontColor: const Color.fromARGB(255, 243, 114, 254),
+                            textAlign: TextAlign.start,
+                          ),
+                          const SizedBox(
+                            height: 7,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              })
+            ]),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/custom_widgets/circlular_text_field.dart
+++ b/lib/custom_widgets/circlular_text_field.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_quiz_app/custom_widgets/styled_text.dart';
+
+class CircularTextField extends StatelessWidget {
+  const CircularTextField(
+      {super.key,
+      required this.circleRadius,
+      this.text = "",
+      this.backgroundColor = Colors.white,
+      this.textColor = Colors.black});
+
+  final double circleRadius;
+  final String text;
+  final Color backgroundColor;
+  final Color textColor;
+
+  @override
+  Widget build(context) {
+    return Container(
+      width: circleRadius * 2,
+      height: circleRadius * 2,
+      margin: const EdgeInsets.only(right: 20, left: 10),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(40),
+      ),
+      child: StyledText(
+        text,
+        fontSize: circleRadius,
+        fontColor: Colors.black,
+        googleFont: true,
+      ),
+    );
+  }
+}

--- a/lib/custom_widgets/styled_text.dart
+++ b/lib/custom_widgets/styled_text.dart
@@ -8,12 +8,14 @@ class StyledText extends StatelessWidget {
     this.fontColor = Colors.white,
     required this.fontSize,
     this.googleFont = false,
+    this.textAlign = TextAlign.center,
   });
 
   final String text;
   final Color fontColor;
   final double fontSize;
   final bool googleFont;
+  final TextAlign textAlign;
 
   @override
   Widget build(context) {
@@ -23,7 +25,7 @@ class StyledText extends StatelessWidget {
           ? GoogleFonts.lato(
               color: fontColor, fontSize: fontSize, fontWeight: FontWeight.bold)
           : TextStyle(color: fontColor, fontSize: fontSize),
-      textAlign: TextAlign.center,
+      textAlign: textAlign,
     );
   }
 }

--- a/lib/quiz.dart
+++ b/lib/quiz.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_quiz_app/custom_widgets/gradient_container.dart';
 import 'package:flutter_quiz_app/data/questions.dart';
 import 'package:flutter_quiz_app/screens/questions_screen.dart';
+import 'package:flutter_quiz_app/screens/results_screen.dart';
 import 'package:flutter_quiz_app/screens/start_screen.dart';
 
 class Quiz extends StatefulWidget {
@@ -17,27 +18,32 @@ class _QuizState extends State<Quiz> {
   Widget? activeScreen;
   List<String> selectedAnswers = [];
 
-  void switchScreen() {
+  void chooseAnswer(String answer) {
+    selectedAnswers.add(answer);
+    if (selectedAnswers.length == questions.length) {
+      redirectToResultsScreen();
+    }
+  }
+
+  void redirectToQuestions() {
     setState(() {
       activeScreen = QuestionsScreen(chooseAnswer);
     });
   }
 
-  void chooseAnswer(String answer) {
-    selectedAnswers.add(answer);
-
-    if (selectedAnswers.length == questions.length) {
-      setState(() {
-        selectedAnswers = [];
-        activeScreen = StartScreen(switchScreen);
-      });
-    }
+  void redirectToResultsScreen() {
+    setState(() {
+      activeScreen = ResultsScreen(
+          selectedAnswers: selectedAnswers,
+          redirectToStart: redirectToQuestions);
+      selectedAnswers = [];
+    });
   }
 
   @override
   void initState() {
     super.initState();
-    activeScreen = StartScreen(switchScreen);
+    activeScreen = StartScreen(redirectToQuestions);
   }
 
   @override

--- a/lib/quiz.dart
+++ b/lib/quiz.dart
@@ -25,6 +25,12 @@ class _QuizState extends State<Quiz> {
     }
   }
 
+  void redirectToStart() {
+    setState(() {
+      activeScreen = StartScreen(redirectToQuestions);
+    });
+  }
+
   void redirectToQuestions() {
     setState(() {
       activeScreen = QuestionsScreen(chooseAnswer);
@@ -34,8 +40,7 @@ class _QuizState extends State<Quiz> {
   void redirectToResultsScreen() {
     setState(() {
       activeScreen = ResultsScreen(
-          selectedAnswers: selectedAnswers,
-          redirectToStart: redirectToQuestions);
+          selectedAnswers: selectedAnswers, redirectToStart: redirectToStart);
       selectedAnswers = [];
     });
   }

--- a/lib/screens/questions_screen.dart
+++ b/lib/screens/questions_screen.dart
@@ -39,7 +39,7 @@ class _QuestionsScreenState extends State<QuestionsScreen> {
           children: [
             StyledText(
               currentQuestion.question,
-              fontColor: Color.fromARGB(255, 205, 169, 255),
+              fontColor: const Color.fromARGB(255, 205, 169, 255),
               fontSize: 24,
               googleFont: true,
             ),

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_quiz_app/custom_widgets/answer_summary.dart';
+import 'package:flutter_quiz_app/custom_widgets/styled_text.dart';
+import 'package:flutter_quiz_app/data/questions.dart';
+
+class ResultsScreen extends StatelessWidget {
+  const ResultsScreen(
+      {super.key,
+      required this.selectedAnswers,
+      required this.redirectToStart});
+
+  final List<String> selectedAnswers;
+  final void Function() redirectToStart;
+
+  Map<String, Object> getSummaryData() {
+    final List<Map<String, Object>> summaryList = [];
+    int correctAnswersCount = 0;
+
+    for (int i = 0; i < selectedAnswers.length; i++) {
+      bool answeredCorrectly = false;
+
+      if (selectedAnswers[i] == questions[i].answers[0]) {
+        correctAnswersCount++;
+        answeredCorrectly = true;
+      }
+
+      summaryList.add({
+        "question_idx": i,
+        "question": questions[i].question,
+        "correctAnswer": questions[i].answers[0],
+        "selectedAnswer": selectedAnswers[i],
+        "answeredCorrectly": answeredCorrectly,
+      });
+    }
+
+    final summaryData = {
+      "noCorrectlyAnswered": correctAnswersCount,
+      "noQuestions": selectedAnswers.length,
+      "summaryList": summaryList,
+    };
+
+    return summaryData;
+  }
+
+  @override
+  Widget build(context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Container(
+        margin: const EdgeInsets.all(40),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AnswerSummary(answerSummary: getSummaryData()),
+            const SizedBox(
+              height: 20,
+            ),
+            TextButton.icon(
+              onPressed: redirectToStart,
+              icon: Container(
+                transform: Matrix4.rotationY(3.14),
+                transformAlignment: Alignment.center,
+                child: const Icon(
+                  Icons.replay,
+                  color: Colors.white,
+                  size: 18,
+                ),
+              ),
+              label: const StyledText("Retake Quiz", fontSize: 15),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/start_screen.dart
+++ b/lib/screens/start_screen.dart
@@ -15,7 +15,7 @@ class StartScreen extends StatelessWidget {
           Image.asset(
             'assets/images/quiz-logo.png',
             width: 250,
-            color: Color.fromARGB(153, 255, 255, 255),
+            color: const Color.fromARGB(153, 255, 255, 255),
           ),
           const SizedBox(
             height: 70,


### PR DESCRIPTION
Proposed changes:

- Developed UI for results screen. 
- Creating circular text field custom widget for results screen. 
- Styled results screen sections.
- Retake Quiz button redirects to start screen. 
- Made app functional 

Screen recording: 

- Different screens: 

<img width="489" alt="Screenshot 2023-05-14 at 2 24 36 AM" src="https://github.com/chiraag918/flutter_quiz_app/assets/39455997/7e49991b-524c-4957-952a-6998ca7f96b0">

<img width="489" alt="Screenshot 2023-05-14 at 2 23 47 AM" src="https://github.com/chiraag918/flutter_quiz_app/assets/39455997/34add3c3-bca7-4e49-bd98-e37f351c83f1">

<img width="491" alt="Screenshot 2023-05-14 at 2 25 21 AM" src="https://github.com/chiraag918/flutter_quiz_app/assets/39455997/cf6438e3-0d99-470f-9886-5e957740b51a">
